### PR TITLE
Add nonce support

### DIFF
--- a/app/scripts/directives/oauth.js
+++ b/app/scripts/directives/oauth.js
@@ -71,7 +71,7 @@ directives.directive('oauth', [
         scope.state         = scope.state         || undefined;
         scope.scope         = scope.scope         || undefined;
         scope.storage       = scope.storage       || 'sessionStorage';
-        scope.nonce         = scope.nonce         || 'k9699'; //TODO make this random 5 digits
+        scope.nonce         = scope.nonce         || true; //use nonce or not. If true(by default) then random nonce generation and validation will be taken care by oauth-ng
       };
 
       var compile = function() {

--- a/app/scripts/services/access-token.js
+++ b/app/scripts/services/access-token.js
@@ -57,7 +57,7 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
    */
   service.destroy = function(){
     //TODO find a better and comprehensive way of dealing with SLO(single logout)
-    if (this.config.revokePath) {
+    if (this.config && this.config.revokePath) {
       var params = 'clientID=' + encodeURIComponent(this.config.clientId) + '&accessToken=' + encodeURIComponent(this.token.access_token);
       var auth = this;
       //TODO circular dependency injection of $http ?
@@ -72,7 +72,7 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
     }
 
     Storage.delete('token');
-    auth.token = null;
+    this.token = null;
     return null;
   };
 

--- a/app/scripts/services/endpoint.js
+++ b/app/scripts/services/endpoint.js
@@ -2,7 +2,7 @@
 
 var endpointClient = angular.module('oauth.endpoint', []);
 
-endpointClient.factory('Endpoint', function() {
+endpointClient.factory('Endpoint', ['Storage', function(Storage) {
 
   var service = {};
 
@@ -46,9 +46,40 @@ endpointClient.factory('Endpoint', function() {
    */
 
   service.redirect = function( overrides ) {
+    overrides = overrides || {};
+    if (this.config.nonce) {
+      var nonce = generateNonce();
+      Storage.set('nonce', nonce);
+      overrides.nonce = nonce;
+    }
     var targetLocation = this.get( overrides );
     window.location.replace(targetLocation);
   };
 
+
+  var generateNonce = function() {
+    var crypto = window.crypto || window.msCrypto;
+    //crypto.getRandomValues should be well supported nowadays, based on http://caniuse.com/#feat=getrandomvalues
+    if (crypto && crypto.getRandomValues) {
+      var array = new Uint32Array(1);
+      crypto.getRandomValues(array);
+      return array[0].toString(36);
+    } else {
+      var byteArrayToLong = function(byteArray) {
+        var value = 0;
+        for (var i = byteArray.length - 1; i >= 0; i--) {
+          value = (value * 256) + byteArray[i];
+        }
+        return value;
+      };
+      var randArray= new Array(4);
+
+      rng_seed_time();
+      new SecureRandom().nextBytes(randArray);
+      return byteArrayToLong(randArray).toString(36);
+    }
+  };
+
+
   return service;
-});
+}]);

--- a/app/scripts/services/id-token.js
+++ b/app/scripts/services/id-token.js
@@ -192,9 +192,11 @@ idTokenService.factory('IdToken', ['Storage', function(Storage) {
           }
         }
 
-        //TODO: nonce support ? probably need to redo current nonce support
-        //if(payload['nonce'] != sessionStorage['nonce'])
-        //  throw new OidcException('invalid nonce');
+        var expectedNonce = Storage.get('nonce');
+        Storage.delete('nonce'); //Delete existing nonce, it's one time use only
+        if (payload.nonce !== expectedNonce)
+          throw new OidcException('invalid nonce');
+
         valid = true;
       } else
         throw new OidcException('Unable to parse JWS payload');

--- a/app/scripts/services/id-token.js
+++ b/app/scripts/services/id-token.js
@@ -204,19 +204,6 @@ idTokenService.factory('IdToken', ['Storage', function(Storage) {
     return valid;
   };
 
-  service.verifyIdTokenSignatureByX509 = function (idToken, x509String) {
-    var x509 = new X509();
-    x509.readCertPEM(x509String);
-    var idParts = idToken.match(/^([^.]+)\.([^.]+)\.([^.]+)$/);
-    var b64sig = null;
-    if (idParts[3].indexOf("-") > -1 || idParts[3].indexOf("_") > -1) { // Base64URL encoding
-      b64sig = idParts[3].replace(/[-]/g, '+').replace(/[_]/g, '/');
-    } else {
-      b64sig = idParts[3];
-    }
-    return x509.subjectPublicKeyRSA.verifyString(idParts[1]+'.'+idParts[2], b64tohex(b64sig));
-  };
-
   /**
    * Verifies the JWS string using the JWK
    * @param {string} jws      The JWS string

--- a/app/scripts/services/oauth-configuration.js
+++ b/app/scripts/services/oauth-configuration.js
@@ -4,12 +4,12 @@ var oauthConfigurationService = angular.module('oauth.configuration', []);
 
 oauthConfigurationService.provider('OAuthConfiguration', function() {
 	var _config = {};
-	
+
 	this.init = function(config, httpProvider) {
 		_config.protectedResources = config.protectedResources || [];
 		httpProvider.interceptors.push('AuthInterceptor');
 	};
-	
+
 	this.$get = function() {
 		return {
 			getConfig: function() {
@@ -18,20 +18,20 @@ oauthConfigurationService.provider('OAuthConfiguration', function() {
 		};
 	};
 })
-.factory('AuthInterceptor', ['OAuthConfiguration', 'AccessToken', function(OAuthConfiguration, AccessToken) {
+.factory('AuthInterceptor', ['OAuthConfiguration', 'Storage', function(OAuthConfiguration, Storage) {
 	return {
 		'request': function(config) {
 			OAuthConfiguration.getConfig().protectedResources.forEach(function(resource) {
 				// If the url is one of the protected resources, we want to see if there's a token and then
 				// add the token if it exists.
 				if (config.url.indexOf(resource) > -1) {
-					var token = AccessToken.get();
+					var token = Storage.get('token');
 					if (token) {
 						config.headers.Authorization = 'Bearer ' + token.access_token;
 					}
 				}
 			});
-			
+
 			return config;
 		}
 	};

--- a/dist/oauth-ng.js
+++ b/dist/oauth-ng.js
@@ -340,7 +340,7 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
    */
   service.destroy = function(){
     //TODO find a better and comprehensive way of dealing with SLO(single logout)
-    if (this.config.revokePath) {
+    if (this.config && this.config.revokePath) {
       var params = 'clientID=' + encodeURIComponent(this.config.clientId) + '&accessToken=' + encodeURIComponent(this.token.access_token);
       var auth = this;
       //TODO circular dependency injection of $http ?
@@ -355,7 +355,7 @@ accessTokenService.factory('AccessToken', ['Storage', '$rootScope', '$location',
     }
 
     Storage.delete('token');
-    auth.token = null;
+    this.token = null;
     return null;
   };
 

--- a/test/spec/services/id-token.js
+++ b/test/spec/services/id-token.js
@@ -223,42 +223,4 @@ describe('IdToken', function() {
     });
   });
 
-  describe('WSO2 RSAwithSHA256 testing', function () {
-
-      it('should verify the signature', function () {
-        var wsoIdToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJTSEEyNTZ3aXRoUlNBIiwieDV0IjoiTkdVMk1EZGpNV1k1WXpSaU1tVXlZamRtTXprelpHTXlORFV3TVRVMk5Ua3pPREF3TnpBd1pRIn0" +
-            ".eyJpc3MiOiJodHRwOi8vd3NvMi5vcmcvZ2F0ZXdheSIsImV4cCI6MTQ0OTE5ODE2MTUwMSwiaHR0cDovL3dzbzIub3JnL2dhdGV3YXkvc3Vic2NyaWJlciI6ImFkbWluIiwiaHR0cDovL3dzbzIub3JnL2dhdGV3YXkvYXBwbGljYXRpb25uYW1lIjoiY2FyZSIsImh0dHA6Ly93c28yLm9yZy9nYXRld2F5L2VuZHVzZXIiOiJhZG1pbkBjYXJlLmNvbSIsICJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2VtYWlsYWRkcmVzcyI6ImFkbWluQGNhcmUuY29tIiwgImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvZ2l2ZW5uYW1lIjoiYWRtaW4iLCAiaHR0cDovL3dzbzIub3JnL2NsYWltcy9sYXN0bmFtZSI6ImFkbWluIiwgImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvcm9sZSI6ImFkbWluLEludGVybmFsL2NhcmUsSW50ZXJuYWwvYWRtaW5fRGVmYXVsdEFwcGxpY2F0aW9uX1BST0RVQ1RJT04sSW50ZXJuYWwvYWRtaW5fQ2FyZV9QUk9EVUNUSU9OLEludGVybmFsL2V2ZXJ5b25lIn0" +
-            ".dSTrkA4tQ53iP-q7bd77Es21d-OsqG0uWqYp02yGlnHVBPJfwTi9qW4NitjH260WWIGnOwGKYiiuE2Zw6YZ_zxc_DJiIf3UczQT7tFfLvusQL69b1szppSwHTFuTMojx9lF_tNEnl0f-lLW3IRDTK9I_4NGlJbXTgx-bkAiLZKo";
-
-        var pem = "-----BEGIN CERTIFICATE-----\n"
-            + "MIICBTCCAW6gAwIBAgIEaq8KvDANBgkqhkiG9w0BAQQFADBHMREwDwYDVQQDEwhj\n"
-            + "YXJlLmNvbTENMAsGA1UECxMETm9uZTEUMBIGA1UEChMLTm9uZSBMPU5vbmUxDTAL\n"
-            + "BgNVBAYTBE5vbmUwHhcNMTUxMDA0MDAyNjMyWhcNMjUxMDMxMDAyNjMyWjBHMREw\n"
-            + "DwYDVQQDEwhjYXJlLmNvbTENMAsGA1UECxMETm9uZTEUMBIGA1UEChMLTm9uZSBM\n"
-            + "PU5vbmUxDTALBgNVBAYTBE5vbmUwgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGB\n"
-            + "AIBzx6MggSa+WXPOMjAisj/BqARDQgE/PPem3GkfoderDBKARdr4ImcNAIWilN65\n"
-            + "vi0ePLS/L6pCXXXDKsmNRvrbkDktrRtQ+iOBB0IKYvILXovcEGTpSFClGnKKULP4\n"
-            + "8rSu5pH1pJGQpBa+p5RYZhdo5+f5N+2PG7SSTeSlQhkHAgMBAAEwDQYJKoZIhvcN\n"
-            + "AQEEBQADgYEAMBbuVdHSEc3YV59XKJWWJ3rA+ZiuPBNAeacRrn2OJf1+TSZpMZ20\n"
-            + "Dh1IeF3cL+xlSi0xKOIKaYCFTlEy61ylOr7gL9Lj2rmsIuKi8joD/6pz/mkpILrv\n"
-            + "dIRWPx/3n8OoV75UBe2KtU5Br2eQbr3/TLiUSyZuWnjcd/oQ1gX1BlA=\n"
-            + "-----END CERTIFICATE-----\n";
-
-        var x509 = new X509();
-        x509.readCertPEM(pem);
-
-        //header.body
-        var sMsg = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJTSEEyNTZ3aXRoUlNBIiwieDV0IjoiTkdVMk1EZGpNV1k1WXpSaU1tVXlZamRtTXprelpHTXlORFV3TVRVMk5Ua3pPREF3TnpBd1pRIn0.eyJpc3MiOiJodHRwOi8vd3NvMi5vcmcvZ2F0ZXdheSIsImV4cCI6MTQ0OTE5ODE2MTUwMSwiaHR0cDovL3dzbzIub3JnL2dhdGV3YXkvc3Vic2NyaWJlciI6ImFkbWluIiwiaHR0cDovL3dzbzIub3JnL2dhdGV3YXkvYXBwbGljYXRpb25uYW1lIjoiY2FyZSIsImh0dHA6Ly93c28yLm9yZy9nYXRld2F5L2VuZHVzZXIiOiJhZG1pbkBjYXJlLmNvbSIsICJodHRwOi8vd3NvMi5vcmcvY2xhaW1zL2VtYWlsYWRkcmVzcyI6ImFkbWluQGNhcmUuY29tIiwgImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvZ2l2ZW5uYW1lIjoiYWRtaW4iLCAiaHR0cDovL3dzbzIub3JnL2NsYWltcy9sYXN0bmFtZSI6ImFkbWluIiwgImh0dHA6Ly93c28yLm9yZy9jbGFpbXMvcm9sZSI6ImFkbWluLEludGVybmFsL2NhcmUsSW50ZXJuYWwvYWRtaW5fRGVmYXVsdEFwcGxpY2F0aW9uX1BST0RVQ1RJT04sSW50ZXJuYWwvYWRtaW5fQ2FyZV9QUk9EVUNUSU9OLEludGVybmFsL2V2ZXJ5b25lIn0';
-        //hex signature string
-        var hSig = '7524eb900e2d439de23feabb6ddefb12cdb577e3aca86d2e5aa629d36c869671d504f25fc138bda96e0d8ad8c7dbad165881a73b018a6228ae136670e9867fcf173f0c98887f751ccd04fbb457cbbeeb102faf5bd6cce9a52c074c5b933288f1f6517fb4d1279747fe94b5b72110d32bd23fe0d1a525b5d3831f9b90088b64aa';
-
-        var isValid = x509.subjectPublicKeyRSA.verifyString(sMsg, hSig);
-        expect(isValid).toEqual(true);
-
-        expect(IdToken.verifyIdTokenSignatureByX509(wsoIdToken, pem)).toEqual(true);
-
-      });
-  });
-
-
 });


### PR DESCRIPTION
@aurorahay You mind taking a quick review ? 
The major change is adding the nonce support. So that each auth request now is identified by a unique `nonce`, if user (or hacker) tries to redo the same auth request(e.g. by clicking back button, or copy & paste the same url in browser address bar), it will result in validation failure.

I also removed some dead code and test, fixed a few very minor issues. Now if you run `grunt test` in the project root, all the tests will pass.
